### PR TITLE
モックに応募フォームを追加

### DIFF
--- a/mock/form/index.vue
+++ b/mock/form/index.vue
@@ -70,12 +70,31 @@
                   <v-btn
                     x-large
                     color="amber darken-4"
-                    block="true"
+                    block
                     dark
-                    @click="validate"
+                    @click.stop="validate"
                     >応募する</v-btn
                   >
                 </div>
+                <v-dialog v-model="dialog" max-width="500">
+                  <v-card>
+                    <v-card-title class="headline"
+                      >求人に応募しました</v-card-title
+                    >
+
+                    <v-card-text>
+                      3営業日中に返信いたします。<br />
+                      誠に恐縮ですが、少々お待ち下さい。
+                    </v-card-text>
+
+                    <v-card-actions>
+                      <v-spacer></v-spacer>
+                      <v-btn color="primary" @click="dialog = false">
+                        OK
+                      </v-btn>
+                    </v-card-actions>
+                  </v-card>
+                </v-dialog>
               </v-form>
             </v-card-text>
           </v-card>
@@ -96,12 +115,14 @@ export default {
       (v) => !!v || 'メールアドレスを入力してください',
       (v) => /.+@.+\..+/.test(v) || '有効なメールアドレスを入力してください'
     ],
-    checkbox: false
+    checkbox: false,
+    dialog: false
   }),
   methods: {
     validate() {
       if (this.$refs.form.validate()) {
         this.snackbar = true
+        this.dialog = true
       }
     }
   }

--- a/mock/form/index.vue
+++ b/mock/form/index.vue
@@ -1,0 +1,109 @@
+<template>
+  <v-layout column justify-center align-center>
+    <v-container>
+      <v-row dense>
+        <v-col cols="12">
+          <v-card>
+            <v-card-text class="pb-1">
+              <div class="d-flex flex-row">
+                <v-chip color="primary mx-1">中途採用（正社員）</v-chip>
+              </div>
+            </v-card-text>
+            <v-card-title class="mb-0 font-weight-black">
+              港区で働く訪問看護師
+            </v-card-title>
+            <v-card-text class="caption">
+              BCC訪問看護ステーション
+            </v-card-text>
+            <v-card-title class="justify-center blue-grey lighten-5">
+              応募内容の登録
+            </v-card-title>
+            <v-card-text>
+              <v-form ref="form" v-model="valid" lazy-validation>
+                <v-row>
+                  <v-col cols="6">
+                    <v-text-field
+                      v-model="nameSeiKanji"
+                      :rules="nameRules"
+                      label="性"
+                      required
+                    ></v-text-field>
+                    <v-text-field
+                      v-model="nameSeiKana"
+                      :rules="nameRules"
+                      label="セイ"
+                      required
+                    ></v-text-field>
+                  </v-col>
+                  <v-col cols="6">
+                    <v-text-field
+                      v-model="nameMeiKanji"
+                      :rules="nameRules"
+                      label="名"
+                      required
+                    ></v-text-field>
+                    <v-text-field
+                      v-model="nameMeiKana"
+                      :rules="nameRules"
+                      label="メイ"
+                      required
+                    ></v-text-field>
+                  </v-col>
+                </v-row>
+                <v-text-field
+                  v-model="email"
+                  :rules="emailRules"
+                  label="メールアドレス"
+                  required
+                ></v-text-field>
+                <div class="d-flex justify-end">
+                  <v-checkbox
+                    v-model="checkbox"
+                    :rules="[
+                      (v) => !!v || '応募には利用規約への同意が必要です'
+                    ]"
+                    label="利用規約に同意しますか?"
+                    required
+                  ></v-checkbox>
+                </div>
+                <div class="d-flex justify-center pb-5">
+                  <v-btn
+                    x-large
+                    color="amber darken-4"
+                    block="true"
+                    dark
+                    @click="validate"
+                    >応募する</v-btn
+                  >
+                </div>
+              </v-form>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-layout>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    valid: true,
+    name: '',
+    email: '',
+    nameRules: [(v) => !!v || '名前を入力してください'],
+    emailRules: [
+      (v) => !!v || 'メールアドレスを入力してください',
+      (v) => /.+@.+\..+/.test(v) || '有効なメールアドレスを入力してください'
+    ],
+    checkbox: false
+  }),
+  methods: {
+    validate() {
+      if (this.$refs.form.validate()) {
+        this.snackbar = true
+      }
+    }
+  }
+}
+</script>

--- a/mock/index.vue
+++ b/mock/index.vue
@@ -107,7 +107,7 @@
               </p>
             </v-card-text>
             <div class="d-flex justify-center pb-5">
-              <v-btn x-large color="amber darken-4" dark>求人に応募する</v-btn>
+              <v-btn x-large block color="amber darken-4" dark>応募する</v-btn>
             </div>
           </v-card>
         </v-col>
@@ -117,7 +117,7 @@
       <v-card flat tile width="100%" class="blue-grey lighten-5">
         <v-card-text>
           <div class="d-flex justify-center pb-5">
-            <v-btn x-large color="amber darken-4" dark to="form"
+            <v-btn x-large block color="amber darken-4" dark to="form"
               >応募する</v-btn
             >
           </div>

--- a/mock/index.vue
+++ b/mock/index.vue
@@ -117,7 +117,9 @@
       <v-card flat tile width="100%" class="blue-grey lighten-5">
         <v-card-text>
           <div class="d-flex justify-center pb-5">
-            <v-btn x-large color="amber darken-4" dark>応募する</v-btn>
+            <v-btn x-large color="amber darken-4" dark to="form"
+              >応募する</v-btn
+            >
           </div>
         </v-card-text>
       </v-card>


### PR DESCRIPTION
#4 対応の一部

# 対応内容
モックに応募フォームを追加

## 詳細
- 応募フォームのページを追加
- 求人ページの「応募ボタン」を押すと、応募フォームへ遷移する
- 応募フォームには最低限の項目、バリデーションだけ追加
- 応募ページで「応募ボタン」を押すと、応募完了のダイアログを表示する