### PR TITLE
feat: 求人を表示する

### DIFF
--- a/configs/get-config.js
+++ b/configs/get-config.js
@@ -1,8 +1,8 @@
 require('dotenv').config()
 
 const nodeEnvValues = {
-  apiClinetId: process.env.API_CLIENT_ID || '',
-  apiClinetSecret: process.env.API_CLIENT_SECRET || ''
+  apiClientId: process.env.API_CLIENT_ID || '',
+  apiClientSecret: process.env.API_CLIENT_SECRET || ''
 }
 
 // 以下がデフォルト値になる

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,8 +2,11 @@
   <v-app dark>
     <v-app-bar app>
       <v-toolbar-title>
+        <!-- TODO: pagesで取得したデータをlayoutで表示する。実現方法が複数案あり迷うのでいったん保留 -->
+        <!-- storeで実現するか？Vue Routerでマッチしたコンポーネントを取得する？ -->
         <p class="pa-0 ma-0">港区で働く訪問看護師</p>
-        <p class="pa-0 ma-0 caption">BCC訪問看護ステーション</p>
+        <!-- TODO: 施設名が求人票のスキームに存在しない。問題ないか？ -->
+        <p class="pa-0 ma-0 caption">（施設名）</p>
       </v-toolbar-title>
     </v-app-bar>
     <v-content>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,0 @@
-<template>
-  <p>本番ページ</p>
-</template>
-
-<script>
-export default {}
-</script>

--- a/pages/jobs/_id.vue
+++ b/pages/jobs/_id.vue
@@ -1,0 +1,117 @@
+<template>
+  <v-layout column justify-center align-center>
+    <v-container>
+      <v-row dense>
+        <v-col cols="12">
+          <v-card>
+            <v-card-text class="pb-1">
+              <div class="d-flex flex-row">
+                <v-chip color="primary mx-1">
+                  <!-- TODO: IDに対応する文字列を取得して表示する -->
+                  （就業形態）
+                </v-chip>
+              </div>
+            </v-card-text>
+            <v-card-title class="mb-0 font-weight-black">
+              {{ name }}
+            </v-card-title>
+            <v-card-text class="caption">
+              <!-- TODO: 施設名が求人票のスキームに存在しない。問題ないか？ -->
+              （施設名）
+            </v-card-text>
+            <v-card-title class="blue-grey lighten-5">
+              求人コード
+            </v-card-title>
+            <v-card-text>
+              <p class="my-2">
+                {{ code }}
+              </p>
+            </v-card-text>
+            <v-card-title class="blue-grey lighten-5">
+              業界、業種、職種
+            </v-card-title>
+            <v-card-text>
+              <p class="my-2">
+                {{ industry }}
+              </p>
+            </v-card-text>
+            <v-card-title class="blue-grey lighten-5">
+              仕事内容
+            </v-card-title>
+            <v-card-text>
+              <p class="my-2">
+                {{ content }}
+              </p>
+            </v-card-text>
+            <v-card-title class="blue-grey lighten-5">
+              勤務地
+            </v-card-title>
+            <v-card-text>
+              <p class="my-2">
+                {{ place }}
+              </p>
+            </v-card-text>
+            <v-card-title class="blue-grey lighten-5">
+              勤務時間
+            </v-card-title>
+            <v-card-text>
+              <p class="my-2">
+                <!-- TODO: jsonデータを整形して表示する -->
+                {{ work_datetime }}
+              </p>
+            </v-card-text>
+            <v-card-title class="blue-grey lighten-5">
+              給与
+            </v-card-title>
+            <v-card-text>
+              <p class="my-2">
+                <!-- TODO: jsonデータを整形して表示する -->
+                {{ salary }}
+              </p>
+            </v-card-text>
+            <v-card-title class="blue-grey lighten-5">
+              契約期間
+            </v-card-title>
+            <v-card-text>
+              <p class="my-2">
+                <!-- TODO: jsonデータを整形して表示する -->
+                {{ contract_period }}
+              </p>
+            </v-card-text>
+            <v-card-title class="blue-grey lighten-5">
+              福利厚生
+            </v-card-title>
+            <v-card-text>
+              <p class="my-2">
+                {{ welfare }}
+              </p>
+            </v-card-text>
+            <div class="d-flex justify-center pb-5">
+              <v-btn x-large block color="amber darken-4" dark>応募する</v-btn>
+            </div>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+    <v-footer fixed="true" padless="true">
+      <v-card flat tile width="100%" class="blue-grey lighten-5">
+        <v-card-text>
+          <div class="d-flex justify-center pb-5">
+            <v-btn x-large block color="amber darken-4" dark to="form"
+              >応募する</v-btn
+            >
+          </div>
+        </v-card-text>
+      </v-card>
+    </v-footer>
+  </v-layout>
+</template>
+
+<script>
+export default {
+  async asyncData({ $axios, env, params }) {
+    const data = await $axios.$get(`${env.apiDomain}/api/jobs/${params.id}`)
+    return { ...data }
+  }
+}
+</script>


### PR DESCRIPTION
# 概要
求人情報をバックエンドから取得して表示する

## 対応内容
-  ジョブIDをURLに含めて、それに対応するデータをバックエンドから取得する
    -  URLのイメージ：${env.apiDomain}/api/jobs/${params.id}
-  取得したデータを求人票ページに表示する
    - 画面はモックのデザインに則って作成

## 疑問
- 施設名が求人票のDBに存在しない。漏れじゃないか確認したい？

## 保留
以下については保留として、ソースコード上にTODOとして残しておいた
- 就業形態の表示
    - IDに対応する文字列を取得して表示する
- jsonデータを整形して表示する
    - 現状はjsonデータを無整形で表示している。（例：{"end": "17:30", "start": "09:00"}）
- ヘッダーで求人票のタイトルを表示する
    - pagesで取得したデータをlayoutで表示する。実現方法が複数案あり迷うのでいったん保留
        - storeで実現するか？Vue Routerでマッチしたコンポーネントを取得する？
 
